### PR TITLE
std::abs() in metrics::imbalance() to account smaller parts in final imbalance value

### DIFF
--- a/kaminpar/utility/metrics.cc
+++ b/kaminpar/utility/metrics.cc
@@ -41,7 +41,8 @@ double imbalance(const PartitionedGraph &p_graph) {
 
   double max_imbalance = 0.0;
   for (const BlockID b : p_graph.blocks()) {
-    max_imbalance = std::max(max_imbalance, p_graph.block_weight(b) / perfect_block_weight - 1.0);
+    max_imbalance = std::max(max_imbalance,
+                             std::abs(p_graph.block_weight(b) / perfect_block_weight - 1.0));
   }
 
   return max_imbalance;


### PR DESCRIPTION
Without `std::abs()` parts which smaller than `perfect_block_weight` gives negative imbalance and so always smaller than any positive `max_imbalance`.