### PR TITLE
Add CMake requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ project(KaMinPar
 set(PROJECT_VENDOR "Daniel Seemaier")
 set(PROJECT_CONTACT "daniel.seemaier@kit.edu")
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ################################################################################
 ## Options                                                                    ##


### PR DESCRIPTION
KaMinPar requires c++ 20. 
Add explicit requirement in the CMake file