### PR TITLE
fix(greedy-balancer)

### DIFF
--- a/kaminpar-shm/refinement/balancer/greedy_balancer.cc
+++ b/kaminpar-shm/refinement/balancer/greedy_balancer.cc
@@ -198,8 +198,8 @@ private:
             _graph->adjacent_nodes(u, [&](const NodeID v) {
               if (!_marker.get(v) && _p_graph->block(v) == from) {
                 add_to_pq(from, v);
+                _marker.set(v);
               }
-              _marker.set(v);
             });
           } else {
             add_to_pq(from, u, u_weight, actual_relative_gain);


### PR DESCRIPTION
Benign but unnecessary race condition setting the marker from multiple threads