### PR TITLE
fix: endless loop in initial ggg bipartitioner

### DIFF
--- a/kaminpar-shm/initial_partitioning/initial_ggg_bipartitioner.cc
+++ b/kaminpar-shm/initial_partitioning/initial_ggg_bipartitioner.cc
@@ -51,6 +51,7 @@ void InitialGGGBipartitioner::fill_bipartition() {
     if (_marker.get(start_node)) {
       start_node = _marker.first_unmarked_element();
     }
+    KASSERT(start_node < _graph->n(), "no unmarked node found");
 
     _queue.push(start_node, compute_gain(start_node));
     _marker.set<true>(start_node);
@@ -86,7 +87,7 @@ void InitialGGGBipartitioner::fill_bipartition() {
         }
       });
     }
-  } while (_block_weights[V2] < _p_ctx->block_weights.perfectly_balanced(V2));
+  } while (_block_weights[V2] <= _p_ctx->block_weights.perfectly_balanced(V2));
 }
 
 [[nodiscard]] EdgeWeight InitialGGGBipartitioner::compute_gain(const NodeID u) const {


### PR DESCRIPTION
The initial greedy graph growing bipartitioner could get stuck in an endless loop if the perfectly balanced block weight of one block is set to 0. To fix this, change < to <=.