### PR TITLE
fix(lp): relace tbbmalloc by standard malloc for sparse ratings

### DIFF
--- a/kaminpar-common/datastructures/fast_reset_array.h
+++ b/kaminpar-common/datastructures/fast_reset_array.h
@@ -25,7 +25,8 @@ public:
   using const_reference = const Value &;
   using size_type = Size;
 
-  explicit FastResetArray(const std::size_t capacity = 0) : _data(capacity, static_array::seq) {
+  explicit FastResetArray(const std::size_t capacity = 0)
+      : _data(capacity, static_array::seq, static_array::std_alloc) {
     RECORD_DATA_STRUCT(capacity * sizeof(value_type), _struct);
   }
 
@@ -107,7 +108,7 @@ public:
   }
 
   void resize(const std::size_t capacity) {
-    _data.resize(capacity, static_array::seq);
+    _data.resize(capacity, static_array::seq, static_array::std_alloc);
 
     IF_HEAP_PROFILING(
         _struct->size = std::max(

--- a/kaminpar-common/datastructures/static_array.h
+++ b/kaminpar-common/datastructures/static_array.h
@@ -386,6 +386,9 @@ private:
     if (_owned_data != nullptr) {
       _owned_data.reset();
     }
+    if (_owned_data_std != nullptr) {
+      _owned_data_std.reset();
+    }
     if (_overcommited_data != nullptr) {
       _overcommited_data.reset();
     }
@@ -412,7 +415,7 @@ private:
   size_type _size = 0;
   size_type _unrestricted_size = 0;
   parallel::tbb_unique_ptr<value_type> _owned_data = nullptr;
-  std::unique_ptr<value_type> _owned_data_std = nullptr;
+  std::unique_ptr<value_type, deleter<value_type>> _owned_data_std = nullptr;
   heap_profiler::unique_ptr<value_type> _overcommited_data = nullptr;
   value_type *_data = nullptr;
 

--- a/kaminpar-common/parallel/tbb_malloc.h
+++ b/kaminpar-common/parallel/tbb_malloc.h
@@ -18,7 +18,9 @@
 #include "sys/mman.h"
 #endif
 
-namespace kaminpar::parallel {
+namespace kaminpar {
+
+namespace parallel {
 
 template <typename T> struct tbb_deleter {
   void operator()(T *p) {
@@ -60,4 +62,33 @@ tbb_unique_ptr<T> make_unique(const std::size_t size, [[maybe_unused]] const boo
   return tbb_unique_ptr<T>(ptr, tbb_deleter<T>{});
 }
 
-} // namespace kaminpar::parallel
+} // namespace parallel
+
+template <typename T>
+std::unique_ptr<T> make_unique(const std::size_t size, [[maybe_unused]] const bool thp) {
+  auto nbytes = sizeof(T) * size;
+  T *ptr = nullptr;
+
+#if defined(__linux__) && defined(KAMINPAR_ENABLE_THP)
+  if (thp) {
+    posix_memalign(reinterpret_cast<void **>(&ptr), 1 << 21, nbytes);
+    madvise(ptr, nbytes, MADV_HUGEPAGE);
+  } else {
+#endif
+    ptr = static_cast<T *>(malloc(nbytes));
+#if defined(__linux__) && defined(KAMINPAR_ENABLE_THP)
+  }
+#endif
+
+  KASSERT(
+      ptr != nullptr, "out of memory: could not allocate " << nbytes << " bytes", assert::light
+  );
+
+  if constexpr (kHeapProfiling && !kPageProfiling) {
+    heap_profiler::HeapProfiler::global().record_alloc(ptr, sizeof(T) * size);
+  }
+
+  return std::unique_ptr<T>(ptr);
+}
+
+} // namespace kaminpar

--- a/kaminpar-shm/label_propagation.h
+++ b/kaminpar-shm/label_propagation.h
@@ -1861,7 +1861,9 @@ private:
 
   template <typename RatingMapETS> void perform(RatingMapETS &rating_map_ets) {
     parallel::Atomic<std::size_t> next_chunk = 0;
-    tbb::parallel_for(static_cast<std::size_t>(0), _chunks.size(), [&](const std::size_t) {
+    DBG << "Number of chunks: " << _chunks.size();
+
+    tbb::parallel_for(static_cast<std::size_t>(0), _chunks.size(), [&](std::size_t) {
       if (should_stop()) {
         return;
       }
@@ -1877,6 +1879,8 @@ private:
       const auto chunk_id = next_chunk.fetch_add(1, std::memory_order_relaxed);
       const auto &chunk = _chunks[chunk_id];
       const auto &permutation = _random_permutations.get(local_rand);
+
+      DBG << chunk_id << " of " << _chunks.size() << " for " << sched_getcpu();
 
       const std::size_t num_sub_chunks =
           std::ceil(1.0 * (chunk.end - chunk.start) / Config::kPermutationSize);


### PR DESCRIPTION
On some machines with recent TBB versions, tbbmalloc can be really slow when allocating the sparse array when aggregating ratings of high degree vertices during single-phase LP. Since I do no know why, lets just use standard malloc here instead.