### PR TITLE
[codex] Disable native tuning in Linux GCC CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,6 +116,7 @@ jobs:
           -DKAMINPAR_ASSERTION_LEVEL=light
           -DKAMINPAR_BUILD_DISTRIBUTED=On
           -DKAMINPAR_BUILD_WITH_DEBUG_SYMBOLS=Off
+          -DKAMINPAR_BUILD_WITH_MTUNE_NATIVE=Off
       - name: GCC Build
         run: >-
           cmake --build ${{github.workspace}}/build


### PR DESCRIPTION
## Summary

- Disable `KAMINPAR_BUILD_WITH_MTUNE_NATIVE` in the Linux GCC Debug workflow job.

## Context

PR #136 failed in the `Compile and run units tests` workflow while CMake was discovering `test_shm_gain_caches`, with the test executable exiting via `Illegal instruction`. The GCC job restores ccache entries and previously inherited the default `-march=native` / `-mtune=native` setting from CMake, which can produce cached objects that are not portable across heterogeneous GitHub-hosted runners.

## Validation

- Ran `git diff --check` locally.
- This is a CI configuration-only change; the GitHub Actions run on this PR should validate the affected job.
