### PR TITLE
[codex] add num vcycles flag

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -210,6 +210,8 @@ Other common command line options include:
 * `--help`: Prints all command line options.
 * `--version`: Prints the build configuration and current version.
 * `--validate`: Enables basic input graph validation.
+* `-V <n>, --num-vcycles <n>`: Runs KaMinPar in V-cycle mode with `n` full V-cycles at
+  the target number of blocks.
 * `-q`: Quiet mode, suppresses all console output.
 
 ## Using the C++ Library Interface
@@ -412,4 +414,3 @@ If you use KaMinPar in an academic setting, please cite the appropriate publicat
   bibsource    = {dblp computer science bibliography, https://dblp.org}
 }
 ```
-

--- a/apps/KaMinPar.cc
+++ b/apps/KaMinPar.cc
@@ -61,6 +61,7 @@ struct ApplicationContext {
   std::vector<BlockWeight> min_block_weights = {};
   std::vector<double> min_block_weight_factors = {};
   bool no_empty_blocks = false;
+  int num_vcycles = 0;
 
   int verbosity = 0;
   bool validate = false;
@@ -178,6 +179,14 @@ The output should be stored in a file and can be used by the -C,--config option.
       ->capture_default_str();
 
   cli.add_flag("--no-empty-blocks", app.no_empty_blocks, "Forbid empty blocks.");
+  cli.add_option(
+         "-V,--num-vcycles",
+         app.num_vcycles,
+         "Use V-cycle partitioning with the given number of full V-cycles at the target number "
+         "of blocks."
+  )
+      ->check(CLI::NonNegativeNumber)
+      ->capture_default_str();
 
   cli.add_option("-s,--seed", app.seed, "Seed for random number generation.")
       ->default_val(app.seed);
@@ -319,6 +328,30 @@ The output should be stored in a file and can be used by the -C,--config option.
   create_all_options(&cli, ctx);
 }
 
+BlockID infer_num_blocks(const ApplicationContext &app) {
+  if (!app.max_block_weight_factors.empty()) {
+    return static_cast<BlockID>(app.max_block_weight_factors.size());
+  }
+
+  if (!app.max_block_weights.empty()) {
+    return static_cast<BlockID>(app.max_block_weights.size());
+  }
+
+  return app.k;
+}
+
+void apply_num_vcycles_option(ApplicationContext &app, Context &ctx) {
+  if (app.num_vcycles == 0) {
+    return;
+  }
+
+  const BlockID final_k = infer_num_blocks(app);
+  app.k = final_k;
+
+  ctx.partitioning.mode = PartitioningMode::VCYCLE;
+  ctx.partitioning.vcycles.assign(static_cast<std::size_t>(app.num_vcycles), final_k);
+}
+
 void output_rearranged_graph(const ApplicationContext &app, const std::vector<BlockID> &partition) {
   if (app.rearranged_graph_filename.empty()) {
     return;
@@ -411,6 +444,8 @@ int main(int argc, char *argv[]) {
   if (app.dry_run) {
     std::exit(0);
   }
+
+  apply_num_vcycles_option(app, ctx);
 
 #ifdef KAMINPAR_ENABLE_TBB_MALLOC
   // If available, use huge pages for large allocations


### PR DESCRIPTION
## Summary

Adds a shared-memory KaMinPar CLI shortcut `-V, --num-vcycles` for running a requested number of full V-cycles at the target number of blocks.

The option forces V-cycle partitioning, infers the final block count from `-k`, `-B`, or `-b`, and expands the count into the existing `ctx.partitioning.vcycles` vector. The README common options list now documents the new flag.

## Validation

- `cmake --build build --target KaMinParApp --parallel`
- `./build/apps/KaMinPar --help | rg -n -- "-V|num-vcycles|p-vcycles"`
- `./build/apps/KaMinPar -G misc/rgg2d.metis -k 4 -V 1 -q`
- `./build/apps/KaMinPar -G misc/rgg2d.metis -B 300 300 300 300 -V 1 -q`
- `./build/apps/KaMinPar -G misc/rgg2d.metis -k 4 -V 1 -v --disable-colors | rg -n "Partitioning mode|RESULT|Number of blocks"`
- `./build/tests/test_shm_endtoend`