### PR TITLE
[codex] tune ueco refinement runtime

### DIFF
--- a/kaminpar-shm/datastructures/partitioned_graph.h
+++ b/kaminpar-shm/datastructures/partitioned_graph.h
@@ -298,6 +298,17 @@ public:
     }
   }
 
+  /**
+   * Recompute block weights from the current partition.
+   *
+   * This is useful after a sequence of partition updates that bypass block weight maintenance,
+   * e.g., when calling `set_block<false>()` in parallel for performance reasons.
+   */
+  inline void recompute_block_weights(const bool sequentially = false) {
+    reinit_dense_block_weights(sequentially);
+    reinit_aligned_block_weights(sequentially);
+  }
+
   //
   // Parallel iteration
   //

--- a/kaminpar-shm/presets.cc
+++ b/kaminpar-shm/presets.cc
@@ -477,14 +477,15 @@ Context create_ueco_context() {
 
   ctx.refinement.lp.num_iterations = 5;
   ctx.refinement.lp.unconstrained_min_improvement_factor = 0.001;
-  ctx.refinement.kway_fm.num_seed_nodes = 25;
+  ctx.refinement.kway_fm.num_seed_nodes = 75;
   ctx.refinement.kway_fm.num_iterations = 10;
   ctx.refinement.kway_fm.unconstrained_num_iterations = 8;
-  ctx.refinement.kway_fm.unconstrained_min_improvement = 0.002;
+  ctx.refinement.kway_fm.unconstrained_min_improvement = 0.005;
   ctx.refinement.kway_fm.unconstrained_penalty_min = 0.2;
   ctx.refinement.kway_fm.unconstrained_penalty_max = 1.0;
   ctx.refinement.kway_fm.unconstrained_rebalancing_node_inclusion_threshold = 0.7;
-  ctx.refinement.kway_fm.minimal_parallelism = 8;
+  ctx.refinement.kway_fm.unconstrained_upper_bound = 1.05;
+  ctx.refinement.kway_fm.minimal_parallelism = 4;
 
   return ctx;
 }

--- a/kaminpar-shm/refinement/fm/unconstrained_fm_refiner.cc
+++ b/kaminpar-shm/refinement/fm/unconstrained_fm_refiner.cc
@@ -983,15 +983,10 @@ public:
     SCOPED_TIMER("FM");
 
     const Graph &graph = concretize<Graph>(p_graph.graph());
-    KwayFMRefinementContext fm_ctx = _fm_ctx;
-    const bool use_fast_fm_settings =
-        graph.n() > 0 && static_cast<std::uint64_t>(graph.m()) >= 18ull * graph.n();
-    if (!use_fast_fm_settings) {
-      fm_ctx.num_seed_nodes = 25;
-      fm_ctx.unconstrained_min_improvement = 0.002;
-      fm_ctx.unconstrained_upper_bound = 0.0;
-      fm_ctx.minimal_parallelism = 8;
+    if (use_stable_fm_path(graph)) {
+      return refine_stable(p_graph, p_ctx);
     }
+    const KwayFMRefinementContext &fm_ctx = _fm_ctx;
 
     TIMED_SCOPE("Initialize gain cache") {
       _shared->gain_cache.initialize(graph, p_graph);
@@ -1175,6 +1170,187 @@ public:
   }
 
 private:
+  [[nodiscard]] bool use_stable_fm_path(const Graph &graph) const {
+    return graph.n() > 0 && static_cast<std::uint64_t>(graph.m()) < 8ull * graph.n();
+  }
+
+  bool refine_stable(PartitionedGraph &p_graph, const PartitionContext &p_ctx) {
+    const Graph &graph = concretize<Graph>(p_graph.graph());
+
+    KwayFMRefinementContext fm_ctx = _fm_ctx;
+    fm_ctx.num_seed_nodes = 25;
+    fm_ctx.unconstrained_min_improvement = 0.002;
+    fm_ctx.unconstrained_upper_bound = 0.0;
+    fm_ctx.minimal_parallelism = 8;
+
+    TIMED_SCOPE("Initialize gain cache") {
+      _shared->gain_cache.initialize(graph, p_graph);
+    };
+
+    const EdgeWeight initial_cut = metrics::edge_cut(p_graph);
+    EdgeWeight best_cut = initial_cut;
+    EdgeWeight cut_before_current_iteration = initial_cut;
+    EdgeWeight total_expected_gain = 0;
+    bool last_iteration_is_best = true;
+
+    StaticArray<BlockID> best_partition;
+    StaticArray<BlockID> round_start_partition;
+    best_partition.resize(graph.n());
+    round_start_partition.resize(graph.n());
+    graph.pfor_nodes([&](const NodeID u) { best_partition[u] = p_graph.block(u); });
+
+    MultiQueueOverloadBalancer balancer(_ctx);
+    balancer.initialize(p_graph);
+    balancer.track_moves([&](const NodeID u, const BlockID from, const BlockID to) {
+      _shared->gain_cache.move(u, from, to);
+      _shared->rebalancing_moves.push_back({.node = u, .from = from, .to = to, .valid = true});
+    });
+
+    using Worker = ufm::LocalizedFMRefiner<Graph, GainCache>;
+
+    std::atomic<int> next_id = 0;
+    tbb::enumerable_thread_specific<std::unique_ptr<Worker>> localized_fm_refiner_ets([&] {
+      std::unique_ptr<Worker> localized_refiner =
+          std::make_unique<Worker>(++next_id, p_ctx, fm_ctx, graph, p_graph, *_shared);
+
+      return localized_refiner;
+    });
+
+    bool unconstrained_enabled = true;
+
+    auto interpolate_unconstrained_penalty = [&](const int iteration) {
+      if (fm_ctx.unconstrained_num_iterations <= 1) {
+        return fm_ctx.unconstrained_penalty_min;
+      }
+
+      const double start = fm_ctx.unconstrained_penalty_min;
+      const double end = fm_ctx.unconstrained_penalty_max;
+      return ((fm_ctx.unconstrained_num_iterations - iteration - 1) * start + iteration * end) /
+             static_cast<double>(fm_ctx.unconstrained_num_iterations - 1);
+    };
+
+    for (int iteration = 0; iteration < fm_ctx.num_iterations; ++iteration) {
+      const bool use_unconstrained_iteration =
+          unconstrained_enabled && iteration < fm_ctx.unconstrained_num_iterations;
+      const double unconstrained_penalty_factor =
+          use_unconstrained_iteration ? interpolate_unconstrained_penalty(iteration) : 0.0;
+
+      _shared->round_moves.clear();
+      _shared->rebalancing_moves.clear();
+      graph.pfor_nodes([&](const NodeID u) { round_start_partition[u] = p_graph.block(u); });
+
+      if (use_unconstrained_iteration) {
+        TIMED_SCOPE("Initialize unconstrained FM data") {
+          _shared->unconstrained.initialize(fm_ctx, graph, p_graph, _shared->gain_cache);
+        };
+      }
+
+      tbb::enumerable_thread_specific<EdgeWeight> expected_gain_ets;
+
+      START_TIMER("Initialize border nodes");
+      _shared->border_nodes.init(p_graph);
+      _shared->border_nodes.shuffle();
+      _shared->abort = 0;
+      STOP_TIMER();
+
+      DBG << "Starting FM iteration " << iteration << " with " << _shared->border_nodes.size()
+          << " border nodes and " << _ctx.parallel.num_threads << " worker threads";
+
+      if (graph.n() == _ctx.partition.n) {
+        START_TIMER("Localized searches, fine level");
+      } else {
+        START_TIMER("Localized searches, coarse level");
+      }
+
+      std::atomic<int> num_finished_workers = 0;
+      const NodeID num_seed_nodes = use_unconstrained_iteration
+                                        ? fm_ctx.num_seed_nodes
+                                        : kConstrainedSeedNodeMultiplier * fm_ctx.num_seed_nodes;
+
+      tbb::parallel_for<int>(0, _ctx.parallel.num_threads, [&](int) {
+        auto &expected_gain = expected_gain_ets.local();
+        auto &localized_refiner = *localized_fm_refiner_ets.local();
+        localized_refiner.configure_round(
+            use_unconstrained_iteration,
+            unconstrained_penalty_factor,
+            fm_ctx.unconstrained_upper_bound,
+            num_seed_nodes
+        );
+
+        while (!_shared->abort.load(std::memory_order_relaxed) &&
+               _shared->border_nodes.has_more()) {
+          if (fm_ctx.dbg_report_progress) {
+            LLOG << " " << _shared->border_nodes.remaining();
+          }
+
+          const auto expected_batch_gain = localized_refiner.run_batch();
+          expected_gain += expected_batch_gain;
+        }
+
+        if (++num_finished_workers >= fm_ctx.minimal_parallelism) {
+          _shared->abort = 1;
+        }
+      });
+      STOP_TIMER();
+
+      const EdgeWeight expected_gain_of_this_iteration = expected_gain_ets.combine(std::plus{});
+      total_expected_gain += expected_gain_of_this_iteration;
+
+      NodeWeight current_overload = metrics::total_overload(p_graph, p_ctx);
+      if (use_unconstrained_iteration && current_overload > 0) {
+        TIMED_SCOPE("Rebalance") {
+          balancer.refine_with_gain_cache(p_graph, p_ctx, graph, _shared->gain_cache);
+        };
+        current_overload = metrics::total_overload(p_graph, p_ctx);
+      }
+
+      if (use_unconstrained_iteration) {
+        interleave_rebalancing_moves_stable(graph, p_graph, p_ctx, round_start_partition);
+      }
+
+      const EdgeWeight current_cut = TIMED_SCOPE("Rollback") {
+        return rollback_to_best_prefix_from_snapshot(
+            graph, p_graph, p_ctx, round_start_partition, cut_before_current_iteration
+        );
+      };
+
+      graph.pfor_nodes([&](const NodeID u) { best_partition[u] = p_graph.block(u); });
+      best_cut = current_cut;
+      last_iteration_is_best = true;
+
+      const EdgeWeight abs_improvement_of_this_iteration =
+          cut_before_current_iteration - current_cut;
+      const double improvement_of_this_iteration =
+          cut_before_current_iteration > 0
+              ? 1.0 * abs_improvement_of_this_iteration / cut_before_current_iteration
+              : 0.0;
+
+      const bool switch_to_constrained_fm =
+          use_unconstrained_iteration && fm_ctx.unconstrained_min_improvement >= 0.0 &&
+          improvement_of_this_iteration < fm_ctx.unconstrained_min_improvement;
+      if (abs_improvement_of_this_iteration <= 0) {
+        break;
+      } else if (switch_to_constrained_fm) {
+        unconstrained_enabled = false;
+      } else if (1.0 - improvement_of_this_iteration > fm_ctx.abortion_threshold) {
+        break;
+      }
+
+      cut_before_current_iteration = current_cut;
+      DBG << "Expected gain of iteration " << iteration << ": " << expected_gain_of_this_iteration
+          << ", total expected gain so far: " << total_expected_gain;
+    }
+
+    TIMED_SCOPE("Rollback") {
+      if (!last_iteration_is_best) {
+        graph.pfor_nodes([&](const NodeID u) { p_graph.set_block(u, best_partition[u]); });
+        _shared->gain_cache.initialize(graph, p_graph);
+      }
+    };
+
+    return best_cut < initial_cut;
+  }
+
   [[nodiscard]] EdgeWeight compute_move_gain(
       const Graph &graph,
       const PartitionedGraph &p_graph,
@@ -1195,6 +1371,119 @@ private:
     });
 
     return conn_to - conn_from;
+  }
+
+  void interleave_rebalancing_moves_stable(
+      const Graph &graph,
+      const PartitionedGraph &p_graph,
+      const PartitionContext &p_ctx,
+      const StaticArray<BlockID> &round_start_partition
+  ) const {
+    if (_shared->rebalancing_moves.empty()) {
+      return;
+    }
+
+    std::vector<GlobalMove> fm_moves(_shared->round_moves.begin(), _shared->round_moves.end());
+    std::vector<GlobalMove> rebalancing_moves(
+        _shared->rebalancing_moves.begin(), _shared->rebalancing_moves.end()
+    );
+
+    constexpr std::size_t kInvalidMoveIndex = std::numeric_limits<std::size_t>::max();
+    std::vector<std::size_t> move_index_of_node(graph.n(), kInvalidMoveIndex);
+    for (std::size_t i = 0; i < fm_moves.size(); ++i) {
+      const GlobalMove &move = fm_moves[i];
+      if (move.valid) {
+        move_index_of_node[move.node] = i;
+      }
+    }
+
+    for (GlobalMove &rebalancing_move : rebalancing_moves) {
+      if (!rebalancing_move.valid) {
+        continue;
+      }
+
+      const std::size_t fm_move_index = move_index_of_node[rebalancing_move.node];
+      if (fm_move_index == kInvalidMoveIndex) {
+        continue;
+      }
+
+      GlobalMove &fm_move = fm_moves[fm_move_index];
+      if (!fm_move.valid || fm_move.to != rebalancing_move.from) {
+        continue;
+      }
+
+      if (fm_move.from == rebalancing_move.to) {
+        fm_move.valid = false;
+        rebalancing_move.valid = false;
+      } else {
+        rebalancing_move.from = fm_move.from;
+        fm_move.valid = false;
+      }
+    }
+
+    std::vector<std::vector<GlobalMove>> rebalancing_moves_by_block(p_graph.k());
+    for (const GlobalMove &move : rebalancing_moves) {
+      if (move.valid) {
+        rebalancing_moves_by_block[move.from].push_back(move);
+      }
+    }
+
+    std::vector<BlockWeight> block_weights(p_graph.k(), 0);
+    for (const NodeID node : graph.nodes()) {
+      block_weights[round_start_partition[node]] += graph.node_weight(node);
+    }
+
+    std::vector<std::size_t> next_rebalancing_move(p_graph.k(), 0);
+    std::vector<GlobalMove> interleaved_moves;
+    interleaved_moves.reserve(fm_moves.size() + rebalancing_moves.size());
+
+    auto apply_to_block_weights = [&](const GlobalMove &move) {
+      const NodeWeight weight = graph.node_weight(move.node);
+      block_weights[move.from] -= weight;
+      block_weights[move.to] += weight;
+    };
+
+    auto insert_moves_to_balance_block = [&](auto &self, const BlockID block) -> void {
+      auto &moves = rebalancing_moves_by_block[block];
+      std::size_t &next = next_rebalancing_move[block];
+
+      while (block_weights[block] > p_ctx.max_block_weight(block) && next < moves.size()) {
+        const GlobalMove move = moves[next++];
+        interleaved_moves.push_back(move);
+        apply_to_block_weights(move);
+
+        if (block_weights[move.to] > p_ctx.max_block_weight(move.to)) {
+          self(self, move.to);
+        }
+      }
+    };
+
+    for (const BlockID block : p_graph.blocks()) {
+      insert_moves_to_balance_block(insert_moves_to_balance_block, block);
+    }
+
+    for (const GlobalMove &move : fm_moves) {
+      if (!move.valid) {
+        continue;
+      }
+
+      interleaved_moves.push_back(move);
+      apply_to_block_weights(move);
+      insert_moves_to_balance_block(insert_moves_to_balance_block, move.to);
+    }
+
+    for (const BlockID block : p_graph.blocks()) {
+      auto &moves = rebalancing_moves_by_block[block];
+      std::size_t &next = next_rebalancing_move[block];
+      while (next < moves.size()) {
+        interleaved_moves.push_back(moves[next++]);
+      }
+    }
+
+    _shared->round_moves.clear();
+    for (const GlobalMove &move : interleaved_moves) {
+      _shared->round_moves.push_back(move);
+    }
   }
 
   void interleave_rebalancing_moves(

--- a/kaminpar-shm/refinement/fm/unconstrained_fm_refiner.cc
+++ b/kaminpar-shm/refinement/fm/unconstrained_fm_refiner.cc
@@ -1171,7 +1171,7 @@ public:
 
 private:
   [[nodiscard]] bool use_stable_fm_path(const Graph &graph) const {
-    return graph.n() > 0 && static_cast<std::uint64_t>(graph.m()) < 9ull * graph.n();
+    return graph.n() > 0 && static_cast<std::uint64_t>(graph.m()) < 6ull * graph.n();
   }
 
   bool refine_stable(PartitionedGraph &p_graph, const PartitionContext &p_ctx) {

--- a/kaminpar-shm/refinement/fm/unconstrained_fm_refiner.cc
+++ b/kaminpar-shm/refinement/fm/unconstrained_fm_refiner.cc
@@ -1171,7 +1171,7 @@ public:
 
 private:
   [[nodiscard]] bool use_stable_fm_path(const Graph &graph) const {
-    return graph.n() > 0 && static_cast<std::uint64_t>(graph.m()) < 8ull * graph.n();
+    return graph.n() > 0 && static_cast<std::uint64_t>(graph.m()) < 9ull * graph.n();
   }
 
   bool refine_stable(PartitionedGraph &p_graph, const PartitionContext &p_ctx) {

--- a/kaminpar-shm/refinement/fm/unconstrained_fm_refiner.cc
+++ b/kaminpar-shm/refinement/fm/unconstrained_fm_refiner.cc
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cmath>
 #include <limits>
 #include <unordered_map>
@@ -98,10 +99,7 @@ public:
         return;
       }
 
-      EdgeWeight total_incident_weight = 0;
-      graph.adjacent_nodes(u, [&](const NodeID, const EdgeWeight weight) {
-        total_incident_weight += weight;
-      });
+      const EdgeWeight total_incident_weight = incident_weight(graph, u);
 
       const BlockID block = p_graph.block(u);
       const EdgeWeight internal_weight = gain_cache.conn(u, block);
@@ -234,10 +232,7 @@ private:
         return;
       }
 
-      EdgeWeight total_incident_weight = 0;
-      graph.adjacent_nodes(u, [&](const NodeID, const EdgeWeight weight) {
-        total_incident_weight += weight;
-      });
+      const EdgeWeight total_incident_weight = incident_weight(graph, u);
 
       const BlockID block = p_graph.block(u);
       const EdgeWeight internal_weight = gain_cache.conn(u, block);
@@ -321,6 +316,19 @@ private:
     });
   }
 
+  template <typename Graph>
+  [[nodiscard]] static EdgeWeight incident_weight(const Graph &graph, const NodeID u) {
+    if (!graph.is_edge_weighted()) {
+      return static_cast<EdgeWeight>(graph.degree(u));
+    }
+
+    EdgeWeight total_incident_weight = 0;
+    graph.adjacent_nodes(u, [&](const NodeID, const EdgeWeight weight) {
+      total_incident_weight += weight;
+    });
+    return total_incident_weight;
+  }
+
   [[nodiscard]] static double gain_per_weight_for_bucket(const std::uint32_t bucket) {
     if (bucket > 1) {
       return std::pow(kBucketFactor, bucket - 2);
@@ -333,9 +341,13 @@ private:
 
   [[nodiscard]] static std::uint32_t bucket_for_gain_per_weight(const double gain_per_weight) {
     if (gain_per_weight >= 1.0) {
-      return static_cast<std::uint32_t>(
-          2 + std::ceil(std::log(gain_per_weight) / std::log(kBucketFactor))
-      );
+      std::uint32_t bucket = 2;
+      double bucket_upper_bound = 1.0;
+      while (gain_per_weight > bucket_upper_bound) {
+        ++bucket;
+        bucket_upper_bound *= kBucketFactor;
+      }
+      return bucket;
     } else if (gain_per_weight > 0.5) {
       return 2;
     } else if (gain_per_weight > 0.0) {
@@ -422,14 +434,15 @@ public:
   void configure_round(
       const bool allow_overloaded_moves,
       const double unconstrained_penalty_factor,
-      const double unconstrained_upper_bound
+      const double unconstrained_upper_bound,
+      const NodeID num_seed_nodes
   ) {
     _allow_overloaded_moves = allow_overloaded_moves;
     _unconstrained_penalty_factor = unconstrained_penalty_factor;
     _unconstrained_upper_bound = unconstrained_upper_bound;
+    _num_seed_nodes = num_seed_nodes;
 
     _local_virtual_weight_delta.resize(_p_graph.k());
-    std::fill(_local_virtual_weight_delta.begin(), _local_virtual_weight_delta.end(), 0);
   }
 
   EdgeWeight run_batch() {
@@ -437,10 +450,11 @@ public:
 
     _seed_nodes.clear();
     _local_moves.clear();
+    _global_moves.clear();
     std::fill(_local_virtual_weight_delta.begin(), _local_virtual_weight_delta.end(), 0);
 
     // Poll seed nodes from the border node arrays
-    _shared.border_nodes.poll(_fm_ctx.num_seed_nodes, _id, [&](const NodeID seed_node) {
+    _shared.border_nodes.poll(_num_seed_nodes, _id, [&](const NodeID seed_node) {
       insert_into_node_pq(_p_graph, _shared.gain_cache, seed_node);
       _seed_nodes.push_back(seed_node);
     });
@@ -499,8 +513,8 @@ public:
         current_total_gain = next_total_gain;
         const bool found_balance_improvement =
             current_total_gain == best_total_gain &&
-            from_weight_before == heaviest_block_weight(_d_graph) &&
-            to_weight_before + node_weight < from_weight_before;
+            to_weight_before + node_weight < from_weight_before &&
+            from_weight_before == heaviest_block_weight(_d_graph);
 
         // If we found a new local minimum, apply the moves to the global
         // partition
@@ -584,6 +598,7 @@ public:
     _local_moves.clear();
     _stopping_policy.reset();
     _touched_nodes.clear();
+    flush_global_moves();
 
     return best_total_gain;
   }
@@ -698,13 +713,6 @@ private:
         _p_ctx.max_block_weight(from) - p_graph.block_weight(from);
 
     gain_cache.gains(u, from, [&](const BlockID to, auto &&compute_gain) {
-      const EdgeWeight unpenalized_gain = compute_gain();
-      if constexpr (!GainCache::kIteratesExactGains) {
-        if (unpenalized_gain == 0) {
-          return;
-        }
-      }
-
       const BlockWeight target_block_weight = p_graph.block_weight(to) + weight;
       const BlockWeight max_block_weight = _p_ctx.max_block_weight(to);
       const BlockWeight block_weight_gap = max_block_weight - target_block_weight;
@@ -714,13 +722,20 @@ private:
         }
       }
 
-      EdgeWeight penalty = 0;
-      if (allow_overloaded_moves()) {
-        if (_unconstrained_upper_bound >= 1.0 &&
-            target_block_weight > _unconstrained_upper_bound * max_block_weight) {
+      if (allow_overloaded_moves() && _unconstrained_upper_bound >= 1.0 &&
+          target_block_weight > _unconstrained_upper_bound * max_block_weight) {
+        return;
+      }
+
+      const EdgeWeight unpenalized_gain = compute_gain();
+      if constexpr (!GainCache::kIteratesExactGains) {
+        if (unpenalized_gain == 0) {
           return;
         }
+      }
 
+      EdgeWeight penalty = 0;
+      if (allow_overloaded_moves()) {
         if (target_block_weight > max_block_weight && unpenalized_gain <= best_gain) {
           return;
         }
@@ -848,7 +863,17 @@ private:
     _shared.node_tracker.set(move.node, fm::NodeTracker::MOVED_GLOBALLY);
     _p_graph.set_block(move.node, move.to);
 
-    _shared.round_moves.push_back(move);
+    _global_moves.push_back(move);
+  }
+
+  void flush_global_moves() {
+    if (_global_moves.empty()) {
+      return;
+    }
+
+    auto out = _shared.round_moves.grow_by(_global_moves.size());
+    std::copy(_global_moves.begin(), _global_moves.end(), out);
+    _global_moves.clear();
   }
 
   [[nodiscard]] BlockWeight heaviest_block_weight(const auto &p_graph) const {
@@ -925,10 +950,12 @@ private:
   std::vector<NodeID> _touched_nodes;
   std::vector<NodeID> _seed_nodes;
   std::vector<GlobalMove> _local_moves;
+  std::vector<GlobalMove> _global_moves;
   std::vector<BlockWeight> _local_virtual_weight_delta;
   bool _allow_overloaded_moves = true;
   double _unconstrained_penalty_factor = 0.0;
   double _unconstrained_upper_bound = 0.0;
+  NodeID _num_seed_nodes = 0;
 };
 
 } // namespace ufm
@@ -937,6 +964,7 @@ template <typename Graph, template <typename> typename GainCacheTemplate>
 class UnconstrainedFMRefinerCore : public Refiner {
   using GainCache = GainCacheTemplate<Graph>;
   using GlobalMove = ufm::GlobalMove;
+  static constexpr NodeID kConstrainedSeedNodeMultiplier = 1;
 
 public:
   UnconstrainedFMRefinerCore(const Context &ctx) : _ctx(ctx), _fm_ctx(ctx.refinement.kway_fm) {}
@@ -955,6 +983,15 @@ public:
     SCOPED_TIMER("FM");
 
     const Graph &graph = concretize<Graph>(p_graph.graph());
+    KwayFMRefinementContext fm_ctx = _fm_ctx;
+    const bool use_fast_fm_settings =
+        graph.n() > 0 && static_cast<std::uint64_t>(graph.m()) >= 18ull * graph.n();
+    if (!use_fast_fm_settings) {
+      fm_ctx.num_seed_nodes = 25;
+      fm_ctx.unconstrained_min_improvement = 0.002;
+      fm_ctx.unconstrained_upper_bound = 0.0;
+      fm_ctx.minimal_parallelism = 8;
+    }
 
     TIMED_SCOPE("Initialize gain cache") {
       _shared->gain_cache.initialize(graph, p_graph);
@@ -964,13 +1001,14 @@ public:
     EdgeWeight best_cut = initial_cut;
     EdgeWeight cut_before_current_iteration = initial_cut;
     EdgeWeight total_expected_gain = 0;
-    bool last_iteration_is_best = true;
 
-    StaticArray<BlockID> best_partition;
+    const bool use_snapshot_rollback =
+        graph.n() > 0 && static_cast<std::uint64_t>(graph.m()) >= 16ull * graph.n();
     StaticArray<BlockID> round_start_partition;
-    best_partition.resize(graph.n());
-    round_start_partition.resize(graph.n());
-    graph.pfor_nodes([&](const NodeID u) { best_partition[u] = p_graph.block(u); });
+    if (use_snapshot_rollback) {
+      round_start_partition.resize(graph.n());
+    }
+    std::vector<BlockWeight> round_start_block_weights(p_graph.k());
 
     MultiQueueOverloadBalancer balancer(_ctx);
     balancer.initialize(p_graph);
@@ -987,7 +1025,7 @@ public:
       // It is important that worker IDs start at 1, otherwise the node
       // tracker won't work
       std::unique_ptr<Worker> localized_refiner =
-          std::make_unique<Worker>(++next_id, p_ctx, _fm_ctx, graph, p_graph, *_shared);
+          std::make_unique<Worker>(++next_id, p_ctx, fm_ctx, graph, p_graph, *_shared);
 
       return localized_refiner;
     });
@@ -995,29 +1033,34 @@ public:
     bool unconstrained_enabled = true;
 
     auto interpolate_unconstrained_penalty = [&](const int iteration) {
-      if (_fm_ctx.unconstrained_num_iterations <= 1) {
-        return _fm_ctx.unconstrained_penalty_min;
+      if (fm_ctx.unconstrained_num_iterations <= 1) {
+        return fm_ctx.unconstrained_penalty_min;
       }
 
-      const double start = _fm_ctx.unconstrained_penalty_min;
-      const double end = _fm_ctx.unconstrained_penalty_max;
-      return ((_fm_ctx.unconstrained_num_iterations - iteration - 1) * start + iteration * end) /
-             static_cast<double>(_fm_ctx.unconstrained_num_iterations - 1);
+      const double start = fm_ctx.unconstrained_penalty_min;
+      const double end = fm_ctx.unconstrained_penalty_max;
+      return ((fm_ctx.unconstrained_num_iterations - iteration - 1) * start + iteration * end) /
+             static_cast<double>(fm_ctx.unconstrained_num_iterations - 1);
     };
 
-    for (int iteration = 0; iteration < _fm_ctx.num_iterations; ++iteration) {
+    for (int iteration = 0; iteration < fm_ctx.num_iterations; ++iteration) {
       const bool use_unconstrained_iteration =
-          unconstrained_enabled && iteration < _fm_ctx.unconstrained_num_iterations;
+          unconstrained_enabled && iteration < fm_ctx.unconstrained_num_iterations;
       const double unconstrained_penalty_factor =
           use_unconstrained_iteration ? interpolate_unconstrained_penalty(iteration) : 0.0;
 
       _shared->round_moves.clear();
       _shared->rebalancing_moves.clear();
-      graph.pfor_nodes([&](const NodeID u) { round_start_partition[u] = p_graph.block(u); });
+      if (use_snapshot_rollback) {
+        graph.pfor_nodes([&](const NodeID u) { round_start_partition[u] = p_graph.block(u); });
+      }
+      for (const BlockID block : p_graph.blocks()) {
+        round_start_block_weights[block] = p_graph.block_weight(block);
+      }
 
       if (use_unconstrained_iteration) {
         TIMED_SCOPE("Initialize unconstrained FM data") {
-          _shared->unconstrained.initialize(_fm_ctx, graph, p_graph, _shared->gain_cache);
+          _shared->unconstrained.initialize(fm_ctx, graph, p_graph, _shared->gain_cache);
         };
       }
 
@@ -1042,6 +1085,9 @@ public:
       }
 
       std::atomic<int> num_finished_workers = 0;
+      const NodeID num_seed_nodes = use_unconstrained_iteration
+                                        ? fm_ctx.num_seed_nodes
+                                        : kConstrainedSeedNodeMultiplier * fm_ctx.num_seed_nodes;
 
       tbb::parallel_for<int>(0, _ctx.parallel.num_threads, [&](int) {
         auto &expected_gain = expected_gain_ets.local();
@@ -1049,7 +1095,8 @@ public:
         localized_refiner.configure_round(
             use_unconstrained_iteration,
             unconstrained_penalty_factor,
-            _fm_ctx.unconstrained_upper_bound
+            fm_ctx.unconstrained_upper_bound,
+            num_seed_nodes
         );
 
         // The workers attempt to extract seed nodes from the border nodes
@@ -1057,7 +1104,7 @@ public:
         // no more border nodes
         while (!_shared->abort.load(std::memory_order_relaxed) &&
                _shared->border_nodes.has_more()) {
-          if (_fm_ctx.dbg_report_progress) {
+          if (fm_ctx.dbg_report_progress) {
             LLOG << " " << _shared->border_nodes.remaining();
           }
 
@@ -1065,7 +1112,7 @@ public:
           expected_gain += expected_batch_gain;
         }
 
-        if (++num_finished_workers >= _fm_ctx.minimal_parallelism) {
+        if (++num_finished_workers >= fm_ctx.minimal_parallelism) {
           _shared->abort = 1;
         }
       });
@@ -1084,20 +1131,22 @@ public:
       }
 
       if (use_unconstrained_iteration) {
-        interleave_rebalancing_moves(graph, p_graph, p_ctx, round_start_partition);
+        interleave_rebalancing_moves(graph, p_graph, p_ctx, round_start_block_weights);
       }
 
-      EdgeWeight current_cut = metrics::edge_cut(p_graph);
-
-      TIMED_SCOPE("Rollback") {
-        current_cut = rollback_to_best_prefix(
-            graph, p_graph, p_ctx, round_start_partition, cut_before_current_iteration
-        );
+      const EdgeWeight current_cut = TIMED_SCOPE("Rollback") {
+        if (use_snapshot_rollback) {
+          return rollback_to_best_prefix_from_snapshot(
+              graph, p_graph, p_ctx, round_start_partition, cut_before_current_iteration
+          );
+        } else {
+          return rollback_to_best_prefix(
+              graph, p_graph, p_ctx, round_start_block_weights, cut_before_current_iteration
+          );
+        }
       };
 
-      graph.pfor_nodes([&](const NodeID u) { best_partition[u] = p_graph.block(u); });
       best_cut = current_cut;
-      last_iteration_is_best = true;
 
       const EdgeWeight abs_improvement_of_this_iteration =
           cut_before_current_iteration - current_cut;
@@ -1107,13 +1156,13 @@ public:
               : 0.0;
 
       const bool switch_to_constrained_fm =
-          use_unconstrained_iteration && _fm_ctx.unconstrained_min_improvement >= 0.0 &&
-          improvement_of_this_iteration < _fm_ctx.unconstrained_min_improvement;
+          use_unconstrained_iteration && fm_ctx.unconstrained_min_improvement >= 0.0 &&
+          improvement_of_this_iteration < fm_ctx.unconstrained_min_improvement;
       if (abs_improvement_of_this_iteration <= 0) {
         break;
       } else if (switch_to_constrained_fm) {
         unconstrained_enabled = false;
-      } else if (1.0 - improvement_of_this_iteration > _fm_ctx.abortion_threshold) {
+      } else if (1.0 - improvement_of_this_iteration > fm_ctx.abortion_threshold) {
         break;
       }
 
@@ -1121,13 +1170,6 @@ public:
       DBG << "Expected gain of iteration " << iteration << ": " << expected_gain_of_this_iteration
           << ", total expected gain so far: " << total_expected_gain;
     }
-
-    TIMED_SCOPE("Rollback") {
-      if (!last_iteration_is_best) {
-        graph.pfor_nodes([&](const NodeID u) { p_graph.set_block(u, best_partition[u]); });
-        _shared->gain_cache.initialize(graph, p_graph);
-      }
-    };
 
     return best_cut < initial_cut;
   }
@@ -1159,7 +1201,7 @@ private:
       const Graph &graph,
       const PartitionedGraph &p_graph,
       const PartitionContext &p_ctx,
-      const StaticArray<BlockID> &round_start_partition
+      const std::vector<BlockWeight> &round_start_block_weights
   ) const {
     if (_shared->rebalancing_moves.empty()) {
       return;
@@ -1170,8 +1212,8 @@ private:
         _shared->rebalancing_moves.begin(), _shared->rebalancing_moves.end()
     );
 
-    constexpr std::size_t kInvalidMoveIndex = std::numeric_limits<std::size_t>::max();
-    std::vector<std::size_t> move_index_of_node(graph.n(), kInvalidMoveIndex);
+    std::unordered_map<NodeID, std::size_t> move_index_of_node;
+    move_index_of_node.reserve(fm_moves.size());
     for (std::size_t i = 0; i < fm_moves.size(); ++i) {
       const GlobalMove &move = fm_moves[i];
       if (move.valid) {
@@ -1184,12 +1226,12 @@ private:
         continue;
       }
 
-      const std::size_t fm_move_index = move_index_of_node[rebalancing_move.node];
-      if (fm_move_index == kInvalidMoveIndex) {
+      const auto fm_move_index_it = move_index_of_node.find(rebalancing_move.node);
+      if (fm_move_index_it == move_index_of_node.end()) {
         continue;
       }
 
-      GlobalMove &fm_move = fm_moves[fm_move_index];
+      GlobalMove &fm_move = fm_moves[fm_move_index_it->second];
       if (!fm_move.valid || fm_move.to != rebalancing_move.from) {
         continue;
       }
@@ -1210,10 +1252,7 @@ private:
       }
     }
 
-    std::vector<BlockWeight> block_weights(p_graph.k(), 0);
-    for (const NodeID node : graph.nodes()) {
-      block_weights[round_start_partition[node]] += graph.node_weight(node);
-    }
+    std::vector<BlockWeight> block_weights = round_start_block_weights;
 
     std::vector<std::size_t> next_rebalancing_move(p_graph.k(), 0);
     std::vector<GlobalMove> interleaved_moves;
@@ -1268,7 +1307,7 @@ private:
     }
   }
 
-  [[nodiscard]] EdgeWeight rollback_to_best_prefix(
+  [[nodiscard]] EdgeWeight rollback_to_best_prefix_from_snapshot(
       const Graph &graph,
       PartitionedGraph &p_graph,
       const PartitionContext &p_ctx,
@@ -1321,6 +1360,90 @@ private:
       const NodeWeight weight = graph.node_weight(move.node);
       update_block_weight(move.from, block_weights[move.from] - weight);
       update_block_weight(move.to, block_weights[move.to] + weight);
+      p_graph.set_block(move.node, move.to);
+      applied_moves[i] = 1;
+
+      if (overloaded_blocks == 0) {
+        const BlockWeight heaviest_block_weight =
+            *std::max_element(block_weights.begin(), block_weights.end());
+        if (current_cut < best_cut ||
+            (current_cut == best_cut && heaviest_block_weight < best_heaviest_block_weight)) {
+          best_cut = current_cut;
+          best_heaviest_block_weight = heaviest_block_weight;
+          best_prefix = i + 1;
+        }
+      }
+    }
+
+    for (std::size_t i = num_moves; i-- > best_prefix;) {
+      if (!applied_moves[i]) {
+        continue;
+      }
+
+      const GlobalMove move = _shared->round_moves[i];
+      if (p_graph.block(move.node) == move.to) {
+        _shared->gain_cache.move(move.node, move.to, move.from);
+        p_graph.set_block(move.node, move.from);
+      }
+    }
+
+    _shared->round_moves.clear();
+    return best_cut;
+  }
+
+  [[nodiscard]] EdgeWeight rollback_to_best_prefix(
+      const Graph &graph,
+      PartitionedGraph &p_graph,
+      const PartitionContext &p_ctx,
+      const std::vector<BlockWeight> &round_start_block_weights,
+      const EdgeWeight round_start_cut
+  ) const {
+    const std::size_t num_moves = _shared->round_moves.size();
+    std::vector<std::uint8_t> reverted_moves(num_moves, 0);
+
+    for (std::size_t i = num_moves; i-- > 0;) {
+      const GlobalMove move = _shared->round_moves[i];
+      if (move.valid && p_graph.block(move.node) == move.to) {
+        _shared->gain_cache.move(move.node, move.to, move.from);
+        p_graph.set_block(move.node, move.from);
+        reverted_moves[i] = 1;
+      }
+    }
+
+    std::vector<BlockWeight> block_weights = round_start_block_weights;
+    std::size_t overloaded_blocks = 0;
+    for (const BlockID block : p_graph.blocks()) {
+      overloaded_blocks += block_weights[block] > p_ctx.max_block_weight(block);
+    }
+
+    EdgeWeight current_cut = round_start_cut;
+    EdgeWeight best_cut = round_start_cut;
+    BlockWeight best_heaviest_block_weight =
+        *std::max_element(block_weights.begin(), block_weights.end());
+    std::size_t best_prefix = 0;
+    std::vector<std::uint8_t> applied_moves(num_moves, 0);
+
+    auto update_block_weight = [&](const BlockID block, const BlockWeight new_weight) {
+      const bool was_overloaded = block_weights[block] > p_ctx.max_block_weight(block);
+      block_weights[block] = new_weight;
+      const bool is_overloaded = block_weights[block] > p_ctx.max_block_weight(block);
+
+      overloaded_blocks += is_overloaded && !was_overloaded;
+      overloaded_blocks -= was_overloaded && !is_overloaded;
+    };
+
+    for (std::size_t i = 0; i < num_moves; ++i) {
+      const GlobalMove move = _shared->round_moves[i];
+      if (!reverted_moves[i] || p_graph.block(move.node) != move.from) {
+        continue;
+      }
+
+      current_cut -= _shared->gain_cache.gain(move.node, move.from, move.to);
+
+      const NodeWeight weight = graph.node_weight(move.node);
+      update_block_weight(move.from, block_weights[move.from] - weight);
+      update_block_weight(move.to, block_weights[move.to] + weight);
+      _shared->gain_cache.move(move.node, move.from, move.to);
       p_graph.set_block(move.node, move.to);
       applied_moves[i] = 1;
 

--- a/kaminpar-shm/refinement/lp/unconstrained_lp_refiner.cc
+++ b/kaminpar-shm/refinement/lp/unconstrained_lp_refiner.cc
@@ -143,7 +143,7 @@ private:
   }
 
   [[nodiscard]] bool use_fast_lp_path() const {
-    return _graph->n() > 0 && static_cast<std::uint64_t>(_graph->m()) >= 18ull * _graph->n();
+    return _graph->n() > 0 && static_cast<std::uint64_t>(_graph->m()) >= 8ull * _graph->n();
   }
 
   template <typename Lambda> void adjacent_nodes(const NodeID u, Lambda &&lambda) const {

--- a/kaminpar-shm/refinement/lp/unconstrained_lp_refiner.cc
+++ b/kaminpar-shm/refinement/lp/unconstrained_lp_refiner.cc
@@ -49,10 +49,14 @@ public:
 
     allocate(p_graph);
 
+    const bool fast_lp_path = use_fast_lp_path();
+
     _balancer.initialize(p_graph);
-    _balancer.track_moves([&](const NodeID u, const BlockID from, const BlockID to) {
-      const Gain gain = compute_move_gain(p_graph, u, from, to);
-      _rebalancing_gain.fetch_add(gain, std::memory_order_relaxed);
+    _balancer.track_moves([&, fast_lp_path](const NodeID u, const BlockID from, const BlockID to) {
+      if (!fast_lp_path) {
+        const Gain gain = compute_move_gain(p_graph, u, from, to);
+        _rebalancing_gain.fetch_add(gain, std::memory_order_relaxed);
+      }
       record_moved_node(u, from);
     });
 
@@ -70,9 +74,13 @@ public:
       }
 
       clear_moved_nodes();
-      _rebalancing_gain.store(0, std::memory_order_relaxed);
 
-      const auto [num_moves, lp_improvement] = perform_round(p_graph);
+      if (!fast_lp_path) {
+        _rebalancing_gain.store(0, std::memory_order_relaxed);
+      }
+
+      const auto [num_moves, lp_improvement] =
+          fast_lp_path ? perform_fast_round(p_graph) : perform_exact_round(p_graph);
       if (num_moves == 0) {
         break;
       }
@@ -83,7 +91,10 @@ public:
         };
       }
 
-      const Gain improvement = lp_improvement + _rebalancing_gain.load(std::memory_order_relaxed);
+      const Gain improvement = TIMED_SCOPE("Compute improvement") {
+        return fast_lp_path ? compute_round_improvement(p_graph)
+                            : lp_improvement + _rebalancing_gain.load(std::memory_order_relaxed);
+      };
       if (metrics::total_overload(p_graph, p_ctx) > 0 || improvement < 0) {
         restore_partition(p_graph);
         break;
@@ -131,6 +142,10 @@ private:
     return _graph->degree(u) <= _r_ctx.lp.large_degree_threshold;
   }
 
+  [[nodiscard]] bool use_fast_lp_path() const {
+    return _graph->n() > 0 && static_cast<std::uint64_t>(_graph->m()) >= 18ull * _graph->n();
+  }
+
   template <typename Lambda> void adjacent_nodes(const NodeID u, Lambda &&lambda) const {
     if (_r_ctx.lp.max_num_neighbors == std::numeric_limits<NodeID>::max()) {
       _graph->adjacent_nodes(u, std::forward<Lambda>(lambda));
@@ -155,7 +170,7 @@ private:
   }
 
   NodeID initialize_active_nodes(const PartitionedGraph &p_graph) {
-    std::atomic<NodeID> active_nodes = 0;
+    tbb::enumerable_thread_specific<NodeID> active_nodes_ets(0);
 
     _graph->pfor_nodes([&](const NodeID u) {
       const std::uint8_t is_active = should_handle_node(u) && is_boundary_node(p_graph, u);
@@ -164,11 +179,11 @@ private:
       _moved[u] = 0;
 
       if (is_active) {
-        active_nodes.fetch_add(1, std::memory_order_relaxed);
+        ++active_nodes_ets.local();
       }
     });
 
-    return active_nodes.load(std::memory_order_relaxed);
+    return active_nodes_ets.combine(std::plus{});
   }
 
   Gain compute_edge_cut(const PartitionedGraph &p_graph) {
@@ -193,9 +208,41 @@ private:
     }
   }
 
-  std::pair<NodeID, Gain> perform_round(PartitionedGraph &p_graph) {
-    std::atomic<NodeID> num_moves = 0;
-    std::atomic<Gain> improvement = 0;
+  std::pair<NodeID, Gain> perform_fast_round(PartitionedGraph &p_graph) {
+    tbb::enumerable_thread_specific<NodeID> num_moves_ets(0);
+    const bool batch_block_weight_updates =
+        tbb::this_task_arena::max_concurrency() >= 32 && p_graph.k() <= 256;
+
+    _graph->pfor_nodes([&](const NodeID u) {
+      if (!_active[u] || !should_handle_node(u)) {
+        return;
+      }
+
+      const auto [to, expected_gain] =
+          find_best_target(p_graph, u, _rating_maps.local(), _tie_breaking_blocks.local());
+      if (expected_gain <= 0 || to == p_graph.block(u)) {
+        return;
+      }
+
+      const BlockID from = p_graph.block(u);
+      if (batch_block_weight_updates) {
+        p_graph.set_block<false>(u, to);
+      } else {
+        p_graph.set_block(u, to);
+      }
+      record_moved_node(u, from);
+      ++num_moves_ets.local();
+    });
+
+    if (batch_block_weight_updates) {
+      p_graph.recompute_block_weights();
+    }
+    return {num_moves_ets.combine(std::plus{}), 0};
+  }
+
+  std::pair<NodeID, Gain> perform_exact_round(PartitionedGraph &p_graph) {
+    tbb::enumerable_thread_specific<NodeID> num_moves_ets(0);
+    tbb::enumerable_thread_specific<Gain> improvement_ets(0);
 
     _graph->pfor_nodes([&](const NodeID u) {
       if (!_active[u] || !should_handle_node(u)) {
@@ -217,11 +264,11 @@ private:
       }
 
       record_moved_node(u, from);
-      num_moves.fetch_add(1, std::memory_order_relaxed);
-      improvement.fetch_add(actual_gain, std::memory_order_relaxed);
+      ++num_moves_ets.local();
+      improvement_ets.local() += actual_gain;
     });
 
-    return {num_moves.load(std::memory_order_relaxed), improvement.load(std::memory_order_relaxed)};
+    return {num_moves_ets.combine(std::plus{}), improvement_ets.combine(std::plus{})};
   }
 
   std::pair<BlockID, Gain> find_best_target(
@@ -342,20 +389,22 @@ private:
   }
 
   void activate_moved_nodes() {
-    for (const auto &nodes : _round_moved_nodes) {
-      for (const NodeID u : nodes) {
-        __atomic_store_n(&_next_active[u], 1, __ATOMIC_RELAXED);
-        adjacent_nodes(u, [&](const NodeID v, const EdgeWeight) {
-          if (accept_neighbor(u, v)) {
-            __atomic_store_n(&_next_active[v], 1, __ATOMIC_RELAXED);
-          }
-        });
+    tbb::parallel_for(_round_moved_nodes.range(), [&](const auto &range) {
+      for (const auto &nodes : range) {
+        for (const NodeID u : nodes) {
+          __atomic_store_n(&_next_active[u], 1, __ATOMIC_RELAXED);
+          adjacent_nodes(u, [&](const NodeID v, const EdgeWeight) {
+            if (accept_neighbor(u, v)) {
+              __atomic_store_n(&_next_active[v], 1, __ATOMIC_RELAXED);
+            }
+          });
+        }
       }
-    }
+    });
   }
 
   NodeID update_active_nodes() {
-    std::atomic<NodeID> active_nodes = 0;
+    tbb::enumerable_thread_specific<NodeID> active_nodes_ets(0);
 
     _graph->pfor_nodes([&](const NodeID u) {
       const std::uint8_t active =
@@ -366,11 +415,11 @@ private:
       _moved[u] = 0;
 
       if (active) {
-        active_nodes.fetch_add(1, std::memory_order_relaxed);
+        ++active_nodes_ets.local();
       }
     });
 
-    return active_nodes.load(std::memory_order_relaxed);
+    return active_nodes_ets.combine(std::plus{});
   }
 
   void restore_partition(PartitionedGraph &p_graph) {

--- a/kaminpar-shm/refinement/lp/unconstrained_lp_refiner.cc
+++ b/kaminpar-shm/refinement/lp/unconstrained_lp_refiner.cc
@@ -8,7 +8,6 @@
 #include "kaminpar-shm/refinement/lp/unconstrained_lp_refiner.h"
 
 #include <algorithm>
-#include <atomic>
 #include <cstdint>
 #include <limits>
 #include <utility>
@@ -49,14 +48,8 @@ public:
 
     allocate(p_graph);
 
-    const bool fast_lp_path = use_fast_lp_path();
-
     _balancer.initialize(p_graph);
-    _balancer.track_moves([&, fast_lp_path](const NodeID u, const BlockID from, const BlockID to) {
-      if (!fast_lp_path) {
-        const Gain gain = compute_move_gain(p_graph, u, from, to);
-        _rebalancing_gain.fetch_add(gain, std::memory_order_relaxed);
-      }
+    _balancer.track_moves([&](const NodeID u, const BlockID from, const BlockID) {
       record_moved_node(u, from);
     });
 
@@ -75,12 +68,7 @@ public:
 
       clear_moved_nodes();
 
-      if (!fast_lp_path) {
-        _rebalancing_gain.store(0, std::memory_order_relaxed);
-      }
-
-      const auto [num_moves, lp_improvement] =
-          fast_lp_path ? perform_fast_round(p_graph) : perform_exact_round(p_graph);
+      const NodeID num_moves = perform_round(p_graph);
       if (num_moves == 0) {
         break;
       }
@@ -92,8 +80,7 @@ public:
       }
 
       const Gain improvement = TIMED_SCOPE("Compute improvement") {
-        return fast_lp_path ? compute_round_improvement(p_graph)
-                            : lp_improvement + _rebalancing_gain.load(std::memory_order_relaxed);
+        return compute_round_improvement(p_graph);
       };
       if (metrics::total_overload(p_graph, p_ctx) > 0 || improvement < 0) {
         restore_partition(p_graph);
@@ -140,10 +127,6 @@ private:
 
   [[nodiscard]] bool should_handle_node(const NodeID u) const {
     return _graph->degree(u) <= _r_ctx.lp.large_degree_threshold;
-  }
-
-  [[nodiscard]] bool use_fast_lp_path() const {
-    return _graph->n() > 0 && static_cast<std::uint64_t>(_graph->m()) >= 8ull * _graph->n();
   }
 
   template <typename Lambda> void adjacent_nodes(const NodeID u, Lambda &&lambda) const {
@@ -208,7 +191,7 @@ private:
     }
   }
 
-  std::pair<NodeID, Gain> perform_fast_round(PartitionedGraph &p_graph) {
+  NodeID perform_round(PartitionedGraph &p_graph) {
     tbb::enumerable_thread_specific<NodeID> num_moves_ets(0);
     const bool batch_block_weight_updates =
         tbb::this_task_arena::max_concurrency() >= 32 && p_graph.k() <= 256;
@@ -237,38 +220,7 @@ private:
     if (batch_block_weight_updates) {
       p_graph.recompute_block_weights();
     }
-    return {num_moves_ets.combine(std::plus{}), 0};
-  }
-
-  std::pair<NodeID, Gain> perform_exact_round(PartitionedGraph &p_graph) {
-    tbb::enumerable_thread_specific<NodeID> num_moves_ets(0);
-    tbb::enumerable_thread_specific<Gain> improvement_ets(0);
-
-    _graph->pfor_nodes([&](const NodeID u) {
-      if (!_active[u] || !should_handle_node(u)) {
-        return;
-      }
-
-      const auto [to, expected_gain] =
-          find_best_target(p_graph, u, _rating_maps.local(), _tie_breaking_blocks.local());
-      if (expected_gain <= 0 || to == p_graph.block(u)) {
-        return;
-      }
-
-      const BlockID from = p_graph.block(u);
-      p_graph.set_block(u, to);
-      const Gain actual_gain = compute_move_gain(p_graph, u, from, to);
-      if (actual_gain <= 0) {
-        p_graph.set_block(u, from);
-        return;
-      }
-
-      record_moved_node(u, from);
-      ++num_moves_ets.local();
-      improvement_ets.local() += actual_gain;
-    });
-
-    return {num_moves_ets.combine(std::plus{}), improvement_ets.combine(std::plus{})};
+    return num_moves_ets.combine(std::plus{});
   }
 
   std::pair<BlockID, Gain> find_best_target(
@@ -334,19 +286,6 @@ private:
 
     map.clear();
     return {best_block, best_gain};
-  }
-
-  Gain compute_move_gain(
-      const PartitionedGraph &p_graph, const NodeID u, const BlockID from, const BlockID to
-  ) const {
-    Gain conn_from = 0;
-    Gain conn_to = 0;
-    adjacent_nodes(u, [&](const NodeID v, const EdgeWeight weight) {
-      const BlockID block = p_graph.block(v);
-      conn_from += block == from ? weight : 0;
-      conn_to += block == to ? weight : 0;
-    });
-    return conn_to - conn_from;
   }
 
   Gain compute_round_improvement(const PartitionedGraph &p_graph) const {
@@ -448,7 +387,6 @@ private:
   tbb::enumerable_thread_specific<RatingMap> _rating_maps;
   tbb::enumerable_thread_specific<std::vector<BlockID>> _tie_breaking_blocks;
   tbb::enumerable_thread_specific<std::vector<NodeID>> _round_moved_nodes;
-  std::atomic<Gain> _rebalancing_gain = 0;
 
   MultiQueueOverloadBalancer _balancer;
 };


### PR DESCRIPTION
## Summary

This PR tunes the `-P ueco` shared-memory refinement path to reduce running time without trading off partition quality.

Changes:
- tune the `ueco` FM defaults toward larger seed batches and earlier unconstrained-to-constrained switching
- add a fast block-weight recomputation path after batched LP moves
- use the faster unconstrained LP path while keeping rollback checks
- route only very sparse graphs through the stable unconstrained FM path, where the speed/quality tradeoff was favorable

## Validation

Local:
- `cmake --build build-codex-ueco --target KaMinParApp --parallel`
- `ctest --test-dir build-codex-ueco -R '(ShmEndToEnd|GainCacheTest)' --output-on-failure -j 8` -> `70/70` passed
- local sample: `/tmp/ueco-fastlp-fmstable6-local-20260523.tsv`

mkexp2 server validation:
- experiment: `2026.05.23-codex-ueco-fmstable6-backus-small`
- tag: `Codex`
- server: Backus only
- dataset: `/nfs/work/graph_benchmark_sets/ufm_paper/small`
- setup: `k=64`, seed `1`, epsilon `0.03`, topology `1x1x64`
- completed: `88/88`
- failures/timeouts/imbalances: `0`
- speed geomean: `1.31837x`
- cut ratio geomean: `0.99859`
- cut ratio arithmetic mean: `0.99884`
