### PR TITLE
[codex] rename reified graph helpers

### DIFF
--- a/kaminpar-dist/datastructures/distributed_graph.h
+++ b/kaminpar-dist/datastructures/distributed_graph.h
@@ -416,19 +416,19 @@ public:
   }
 
   [[nodiscard]] inline DistributedCSRGraph &csr_graph() {
-    return graph::concretize<DistributedCSRGraph>(*_underlying_graph);
+    return graph::as_concrete_graph<DistributedCSRGraph>(*_underlying_graph);
   }
 
   [[nodiscard]] inline const DistributedCSRGraph &csr_graph() const {
-    return graph::concretize<DistributedCSRGraph>(*_underlying_graph);
+    return graph::as_concrete_graph<DistributedCSRGraph>(*_underlying_graph);
   }
 
   [[nodiscard]] inline DistributedCompressedGraph &compressed_graph() {
-    return graph::concretize<DistributedCompressedGraph>(*_underlying_graph);
+    return graph::as_concrete_graph<DistributedCompressedGraph>(*_underlying_graph);
   }
 
   [[nodiscard]] inline const DistributedCompressedGraph &compressed_graph() const {
-    return graph::concretize<DistributedCompressedGraph>(*_underlying_graph);
+    return graph::as_concrete_graph<DistributedCompressedGraph>(*_underlying_graph);
   }
 
   template <typename Lambda1, typename Lambda2>
@@ -440,16 +440,16 @@ public:
     return graph::reified(*_underlying_graph, std::forward<Lambda>(l));
   }
 
-  template <typename ConcretizedGraph> [[nodiscard]] bool is() const {
-    return graph::is<ConcretizedGraph>(*_underlying_graph);
+  template <typename ConcreteGraph> [[nodiscard]] bool is() const {
+    return graph::is<ConcreteGraph>(*_underlying_graph);
   }
 
-  template <typename ConcretizedGraph> [[nodiscard]] ConcretizedGraph &concretize() {
-    return graph::concretize<ConcretizedGraph>(*_underlying_graph);
+  template <typename ConcreteGraph> [[nodiscard]] ConcreteGraph &as_concrete_graph() {
+    return graph::as_concrete_graph<ConcreteGraph>(*_underlying_graph);
   }
 
-  template <typename ConcretizedGraph> [[nodiscard]] const ConcretizedGraph &concretize() const {
-    return graph::concretize<ConcretizedGraph>(*_underlying_graph);
+  template <typename ConcreteGraph> [[nodiscard]] const ConcreteGraph &as_concrete_graph() const {
+    return graph::as_concrete_graph<ConcreteGraph>(*_underlying_graph);
   }
 
 private:

--- a/kaminpar-dist/datastructures/reify_graph.h
+++ b/kaminpar-dist/datastructures/reify_graph.h
@@ -39,23 +39,23 @@ decltype(auto) reified(const AbstractDistributedGraph &graph, Lambda &&l) {
   __builtin_unreachable();
 }
 
-template <typename ConcretizedGraph> [[nodiscard]] bool is(const AbstractDistributedGraph &graph) {
-  return dynamic_cast<const ConcretizedGraph *>(&graph) != nullptr;
+template <typename ConcreteGraph> [[nodiscard]] bool is(const AbstractDistributedGraph &graph) {
+  return dynamic_cast<const ConcreteGraph *>(&graph) != nullptr;
 }
 
-template <typename ConcretizedGraph>
-[[nodiscard]] ConcretizedGraph &concretize(const AbstractDistributedGraph &graph) {
+template <typename ConcreteGraph>
+[[nodiscard]] ConcreteGraph &as_concrete_graph(const AbstractDistributedGraph &graph) {
   KASSERT(
-      is<ConcretizedGraph>(graph), "underlying graph is not a " << typeid(ConcretizedGraph).name()
+      is<ConcreteGraph>(graph), "underlying graph is not a " << typeid(ConcreteGraph).name()
   );
-  return *static_cast<ConcretizedGraph *>(&graph);
+  return *static_cast<ConcreteGraph *>(&graph);
 }
 
-template <typename ConcretizedGraph> ConcretizedGraph &concretize(AbstractDistributedGraph &graph) {
+template <typename ConcreteGraph> ConcreteGraph &as_concrete_graph(AbstractDistributedGraph &graph) {
   KASSERT(
-      is<ConcretizedGraph>(graph), "underlying graph is not a " << typeid(ConcretizedGraph).name()
+      is<ConcreteGraph>(graph), "underlying graph is not a " << typeid(ConcreteGraph).name()
   );
-  return dynamic_cast<ConcretizedGraph &>(graph);
+  return dynamic_cast<ConcreteGraph &>(graph);
 }
 
 } // namespace kaminpar::dist::graph

--- a/kaminpar-dist/refinement/jet/jet_refiner.cc
+++ b/kaminpar-dist/refinement/jet/jet_refiner.cc
@@ -465,7 +465,7 @@ JetRefinerFactory::create(DistributedPartitionedGraph &p_graph, const PartitionC
       assert::always
   );
 
-  const DistributedCSRGraph &csr_graph = p_graph.graph().concretize<DistributedCSRGraph>();
+  const DistributedCSRGraph &csr_graph = p_graph.graph().as_concrete_graph<DistributedCSRGraph>();
 
   switch (_ctx.refinement.jet.gain_cache_strategy) {
 #ifdef KAMINPAR_EXPERIMENTAL

--- a/kaminpar-shm/coarsening/sparsification_cluster_coarsener.cc
+++ b/kaminpar-shm/coarsening/sparsification_cluster_coarsener.cc
@@ -92,7 +92,7 @@ bool SparsificationClusterCoarsener::coarsen() {
     auto *coarsened_downcast = dynamic_cast<CoarseGraphImpl *>(coarsened.get());
     StaticArray<NodeID> mapping = std::move(coarsened_downcast->get_mapping());
     Graph graph = std::move(coarsened_downcast->get());
-    CSRGraph &csr = concretize<CSRGraph>(graph);
+    CSRGraph &csr = as_concrete_graph<CSRGraph>(graph);
 
     const NodeID c_n = csr.n();
     const EdgeID c_m = csr.m();
@@ -122,7 +122,7 @@ bool SparsificationClusterCoarsener::coarsen() {
       // Contraction code is racy: mapping might have changed
       auto *recontracted_impl = dynamic_cast<CoarseGraphImpl *>(recontracted.get());
       mapping = std::move(recontracted_impl->get_mapping());
-      return std::move(concretize<CSRGraph>(recontracted->get()));
+      return std::move(as_concrete_graph<CSRGraph>(recontracted->get()));
     }();
 
     _prev_sparsification_target_m = target_sparsified_m;
@@ -165,7 +165,7 @@ SparsificationClusterCoarsener::recontract_with_threshold_sparsification(
 ) {
   if (target_m < 2) {
     return contract_and_sparsify_clustering(
-        concretize<CSRGraph>(current()),
+        as_concrete_graph<CSRGraph>(current()),
         std::move(mapping),
         c_n,
         [](const NodeID, const EdgeWeight, const NodeID) { return false; },
@@ -218,7 +218,7 @@ SparsificationClusterCoarsener::recontract_with_threshold_sparsification(
   };
 
   return contract_and_sparsify_clustering(
-      concretize<CSRGraph>(current()),
+      as_concrete_graph<CSRGraph>(current()),
       std::move(mapping),
       c_n,
       sample_edge,

--- a/kaminpar-shm/datastructures/graph.h
+++ b/kaminpar-shm/datastructures/graph.h
@@ -62,23 +62,23 @@ template <typename Lambda> decltype(auto) reified(const Graph &graph, Lambda &&l
   return reified(graph, std::forward<Lambda>(l), std::forward<Lambda>(l));
 }
 
-template <typename ConcretizedGraph> [[nodiscard]] ConcretizedGraph &concretize(Graph &graph) {
+template <typename ConcreteGraph> [[nodiscard]] ConcreteGraph &as_concrete_graph(Graph &graph) {
   KASSERT(
-      dynamic_cast<ConcretizedGraph *>(graph.underlying_graph()) != nullptr,
-      "underlying graph is not a " << typeid(ConcretizedGraph).name()
+      dynamic_cast<ConcreteGraph *>(graph.underlying_graph()) != nullptr,
+      "underlying graph is not a " << typeid(ConcreteGraph).name()
   );
 
-  return *static_cast<ConcretizedGraph *>(graph.underlying_graph());
+  return *static_cast<ConcreteGraph *>(graph.underlying_graph());
 }
 
-template <typename ConcretizedGraph>
-[[nodiscard]] const ConcretizedGraph &concretize(const Graph &graph) {
+template <typename ConcreteGraph>
+[[nodiscard]] const ConcreteGraph &as_concrete_graph(const Graph &graph) {
   KASSERT(
-      dynamic_cast<const ConcretizedGraph *>(graph.underlying_graph()) != nullptr,
-      "underlying graph is not a " << typeid(ConcretizedGraph).name()
+      dynamic_cast<const ConcreteGraph *>(graph.underlying_graph()) != nullptr,
+      "underlying graph is not a " << typeid(ConcreteGraph).name()
   );
 
-  return *static_cast<const ConcretizedGraph *>(graph.underlying_graph());
+  return *static_cast<const ConcreteGraph *>(graph.underlying_graph());
 }
 
 /*!
@@ -87,7 +87,7 @@ template <typename ConcretizedGraph>
  *
  * `Component` may only take one template argument: the concretized graph class.
  */
-template <template <typename> typename Component> struct AnyGraphComponent {
+template <template <typename> typename Component> struct ReifiedGraphComponent {
   std::variant<std::monostate, Component<CSRGraph>, Component<CompressedGraph>> obj;
 
   /*!

--- a/kaminpar-shm/refinement/balancer/multi_queue_overload_balancer.h
+++ b/kaminpar-shm/refinement/balancer/multi_queue_overload_balancer.h
@@ -178,7 +178,7 @@ private:
   StaticArray<std::size_t> _pq_handles;
   StaticArray<std::uint8_t> _node_state;
 
-  AnyGraphComponent<GainCache> _gain_cache;
+  ReifiedGraphComponent<GainCache> _gain_cache;
 
   MoveTracker _move_tracker = nullptr;
 };

--- a/kaminpar-shm/refinement/balancer/overload_balancer.h
+++ b/kaminpar-shm/refinement/balancer/overload_balancer.h
@@ -79,7 +79,7 @@ private:
 
   StaticArray<std::uint8_t> _moved_nodes;
 
-  AnyGraphComponent<GainCache> _gain_cache;
+  ReifiedGraphComponent<GainCache> _gain_cache;
 
   MoveTracker _move_tracker = nullptr;
 };

--- a/kaminpar-shm/refinement/balancer/underload_balancer.h
+++ b/kaminpar-shm/refinement/balancer/underload_balancer.h
@@ -72,7 +72,7 @@ private:
   MaxMultiQueue<NodeID, float> _mq;
 
   StaticArray<BlockID> _node_target;
-  AnyGraphComponent<GainCache> _gain_cache;
+  ReifiedGraphComponent<GainCache> _gain_cache;
 };
 
 } // namespace kaminpar::shm

--- a/kaminpar-shm/refinement/fm/fm_refiner.cc
+++ b/kaminpar-shm/refinement/fm/fm_refiner.cc
@@ -469,7 +469,7 @@ public:
     SCOPED_HEAP_PROFILER("FM");
     SCOPED_TIMER("FM");
 
-    const Graph &graph = concretize<Graph>(p_graph.graph());
+    const Graph &graph = as_concrete_graph<Graph>(p_graph.graph());
 
     TIMED_SCOPE("Initialize gain cache") {
       _shared->gain_cache.initialize(graph, p_graph);

--- a/kaminpar-shm/refinement/fm/unconstrained_fm_refiner.cc
+++ b/kaminpar-shm/refinement/fm/unconstrained_fm_refiner.cc
@@ -982,7 +982,7 @@ public:
     SCOPED_HEAP_PROFILER("FM");
     SCOPED_TIMER("FM");
 
-    const Graph &graph = concretize<Graph>(p_graph.graph());
+    const Graph &graph = as_concrete_graph<Graph>(p_graph.graph());
     if (use_stable_fm_path(graph)) {
       return refine_stable(p_graph, p_ctx);
     }
@@ -1175,7 +1175,7 @@ private:
   }
 
   bool refine_stable(PartitionedGraph &p_graph, const PartitionContext &p_ctx) {
-    const Graph &graph = concretize<Graph>(p_graph.graph());
+    const Graph &graph = as_concrete_graph<Graph>(p_graph.graph());
 
     KwayFMRefinementContext fm_ctx = _fm_ctx;
     fm_ctx.num_seed_nodes = 25;


### PR DESCRIPTION
## Summary

Renames the graph helper APIs around reified concrete graph access:

- `concretize<...>(graph)` is now `as_concrete_graph<...>(graph)` in shared-memory and distributed graph helpers.
- `AnyGraphComponent<...>` is now `ReifiedGraphComponent<...>` for the shared-memory graph-specialized component holder.
- Updates all call sites in shared-memory and distributed code.

## Motivation

The new names better describe the helpers' behavior: checked access to an expected concrete graph type, and storage for a component specialized by the reified graph representation.

## Verification

- `cmake --build /tmp/kaminpar-codex-build-default --target KaMinPar -j 8`
- `cmake --build /tmp/kaminpar-codex-build-dist --target dKaMinPar -j 8`