### PR TITLE
[codex] Fix parallel max identity for floating-point values

### DIFF
--- a/kaminpar-common/parallel/algorithm.h
+++ b/kaminpar-common/parallel/algorithm.h
@@ -106,7 +106,7 @@ template <typename Container> typename Container::value_type max_element(const C
     const Container &_r;
 
   public:
-    value_t _ans{std::numeric_limits<value_t>::min()};
+    value_t _ans{std::numeric_limits<value_t>::lowest()};
 
     void operator()(const tbb::blocked_range<size_t> &indices) {
       const Container &r = _r;
@@ -140,7 +140,7 @@ typename std::iterator_traits<InputIt>::value_type max_element(InputIt begin, In
     InputIt _begin;
 
   public:
-    value_t _ans{std::numeric_limits<value_t>::min()};
+    value_t _ans{std::numeric_limits<value_t>::lowest()};
 
     void operator()(const tbb::blocked_range<size_t> &indices) {
       InputIt begin = _begin;
@@ -177,7 +177,7 @@ typename std::iterator_traits<InputIt>::value_type max_difference(InputIt begin,
 
   // Catch special cases: zero or one element
   if (size == 0) {
-    return std::numeric_limits<value_t>::min();
+    return std::numeric_limits<value_t>::lowest();
   } else if (size == 1) {
     return 0;
   }
@@ -186,7 +186,7 @@ typename std::iterator_traits<InputIt>::value_type max_difference(InputIt begin,
     InputIt _begin;
 
   public:
-    value_t _ans = std::numeric_limits<value_t>::min();
+    value_t _ans = std::numeric_limits<value_t>::lowest();
 
     void operator()(const tbb::blocked_range<size_t> &indices) {
       const InputIt begin = _begin;

--- a/tests/common/parallel/algorithm_test.cc
+++ b/tests/common/parallel/algorithm_test.cc
@@ -21,6 +21,13 @@ TEST(ParallelAlgorithmTest, prefix_sum_with_multiple_elements_inplace) {
   EXPECT_THAT(data, ElementsAre(1, 3, 6, 10, 15));
 }
 
+TEST(ParallelAlgorithmTest, prefix_sum_with_zero_elements) {
+  std::vector<int> input;
+  std::vector<int> output{42};
+  parallel::prefix_sum(input.begin(), input.end(), output.begin());
+  EXPECT_THAT(output, ElementsAre(42));
+}
+
 TEST(ParallelAlgorithmTest, max_element_with_single_element) {
   std::vector<int> data{1};
   const int result = parallel::max_element(data);
@@ -33,6 +40,12 @@ TEST(ParallelAlgorithmTest, max_element_with_multiple_elements) {
   EXPECT_EQ(result, 10);
 }
 
+TEST(ParallelAlgorithmTest, max_element_with_negative_floating_point_elements) {
+  std::vector<double> data{-4.5, -1.25, -8.0};
+  const double result = parallel::max_element(data);
+  EXPECT_DOUBLE_EQ(result, -1.25);
+}
+
 TEST(ParallelAlgorithmTest, max_element_with_single_element_subset) {
   std::vector<int> data{1, 2, 3};
   const int result = parallel::max_element(data.begin() + 1, data.begin() + 2);
@@ -43,6 +56,12 @@ TEST(ParallelAlgorithmTest, max_element_with_iterators) {
   std::vector<int> data{1, 2, 3};
   const int result = parallel::max_element(data.begin(), data.end());
   EXPECT_EQ(result, 3);
+}
+
+TEST(ParallelAlgorithmTest, max_element_with_negative_floating_point_iterators) {
+  std::vector<double> data{-4.5, -1.25, -8.0};
+  const double result = parallel::max_element(data.begin(), data.end());
+  EXPECT_DOUBLE_EQ(result, -1.25);
 }
 
 TEST(ParallelAlgorithmTest, accumulate_with_zero_elements) {
@@ -107,10 +126,24 @@ TEST(ParallelAlgorithmTest, accumulate_large_subset) {
   EXPECT_EQ(result, (1000 * 999) / 2);
 }
 
+TEST(ParallelAlgorithmTest, accumulate_with_unary_operation) {
+  std::vector<int> data{1, 2, 3};
+  const int result = parallel::accumulate(data.begin(), data.end(), 10, [](const int value) {
+    return value * value;
+  });
+  EXPECT_EQ(result, 24);
+}
+
 TEST(ParallelAlgorithmTest, max_difference_with_zero_elements) {
   std::vector<int> data;
   const int result = parallel::max_difference(data);
   EXPECT_EQ(result, std::numeric_limits<int>::min());
+}
+
+TEST(ParallelAlgorithmTest, max_difference_with_zero_floating_point_elements) {
+  std::vector<double> data;
+  const double result = parallel::max_difference(data);
+  EXPECT_DOUBLE_EQ(result, std::numeric_limits<double>::lowest());
 }
 
 TEST(ParallelAlgorithmTest, max_difference_with_one_element) {
@@ -141,6 +174,12 @@ TEST(ParallelAlgorithmTest, max_difference_last_pair_is_max) {
   std::vector<int> data{1, 5, 6, 7, 17};
   const int result = parallel::max_difference(data);
   EXPECT_EQ(result, 10);
+}
+
+TEST(ParallelAlgorithmTest, max_difference_with_negative_floating_point_differences) {
+  std::vector<double> data{5.0, 3.5, 0.5};
+  const double result = parallel::max_difference(data);
+  EXPECT_DOUBLE_EQ(result, -1.5);
 }
 
 } // namespace kaminpar


### PR DESCRIPTION
## Summary

Fixes the identity value used by `parallel::max_element()` and `parallel::max_difference()` from `std::numeric_limits<T>::min()` to `std::numeric_limits<T>::lowest()`.

## Root Cause

For floating-point types, `min()` is the smallest positive normalized value, not the most negative representable value. That meant all-negative floating-point inputs could produce an incorrect positive result when computing maxima.

## Tests

Added regression coverage for:

- negative floating-point `max_element()` through container and iterator overloads
- empty floating-point `max_difference()`
- negative floating-point differences
- empty `prefix_sum()`
- unary-operation `accumulate()`

Validation run locally:

```sh
cmake --build build --target test_common_parallel_algorithm -j 8
ctest --test-dir build -R '^ParallelAlgorithmTest\.' --output-on-failure
```

All 28 `ParallelAlgorithmTest` cases passed.